### PR TITLE
Add cumulusci integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,9 @@
-# This file is used for Git repositories to specify intentionally untracked files that Git should ignore. 
-# If you are not using git, you can delete this file. For more information see: https://git-scm.com/docs/gitignore
-# For useful gitignore templates see: https://github.com/github/gitignore
-
-# Salesforce cache
-.sfdx/
-.localdevserver/
+# Salesforce / SFDX / CCI
+.cci
+.sfdx
+/src.orig
+/src
+.localdevserver
 
 # LWC VSCode autocomplete
 **/lwc/jsconfig.json
@@ -19,10 +18,23 @@ yarn-error.log*
 # Dependency directories
 node_modules/
 
-# Eslint cache
-.eslintcache
 
-# MacOS system files
+# Python
+*.pyc
+__pycache__
+
+# Robot Framework results
+robot/lwc-redux/results/
+
+# Editors
+*.sublime-project
+*.sublime-workspace
+.vscode
+.idea
+.project
+.settings
+
+# Misc
 .DS_Store
 
 # Windows system files

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /src.orig
 /src
 .localdevserver
+.eslintcache
 
 # LWC VSCode autocomplete
 **/lwc/jsconfig.json

--- a/README.md
+++ b/README.md
@@ -36,3 +36,21 @@ To see how to use LWC Redux in practice, we’ll show a step-by-step example by 
 ## Examples
 
 Go to Examples folder in the repository or [refer examples page](http://lwc-redux.com/examples)
+
+## CCI Integration
+
+Add to your cumulusci.yml:
+
+```
+sources:
+  lwc-redux:
+    github: https://github.com/chandrakiran-dev/lwc-redux
+```
+
+Add to your cci flow:
+
+```
+task: lwc-redux:deploy
+options:
+    path: force-app/main/default
+```

--- a/README.md
+++ b/README.md
@@ -1,37 +1,12 @@
-# Introducing Redux with Lightning web components(LWC)
+# lwc-redux
 
-[LWC-redux](http://lwc-redux.com/) is a [LWC](https://developer.salesforce.com/blogs/2018/12/introducing-lightning-web-components.html) binding for [Redux](https://redux.js.org/introduction/getting-started#basic-example). It will allow your Lightning Web Components to read data from a Redux store, and dispatch actions to the store to update data.
+Add a brief description of this project here, in Markdown format.
+It will be shown on the main page of the project's GitHub repository.
 
-LWC-redux helps you to write application that behaves consistently and provide state management to the application. It's also separate the JS business and design layers.
+## Development
 
-## Installation
+To work on this project in a scratch org:
 
-To install the LWC-redux, we only need to click on the below button. It will redirect you to another page where you can select production/sandbox org and proceed with 'Login to Salesforce' button.
-[Click here to install](http://lwc-redux.com/quick-start#installation)
-
-There are two types of developer processes or models supported in Salesforce Extensions for VS Code and Salesforce CLI. These models are explained below. Each model offers pros and cons and is fully supported.
-
-## Why Use LWC Redux?
-
-Redux itself is a standalone library that can be used with any UI layer or framework, including LWC, React, Angular, Vue, Ember, and vanilla JS. Although Redux and React are commonly used together, they are independent of each other.
-
-If you are using Redux with any kind of UI framework, you will normally use a "UI binding" library to tie Redux together with your UI framework, rather than directly interacting with the store from your UI code.
-
-LWC Redux is the Redux UI binding library for LWC. If you are using Redux and LWC together, you should also use LWC Redux to bind these two libraries.
-
-##### It is the Redux UI Bindings for LWC.
-##### It Encourages Good LWC Architecture.
-##### It Implements Performance Optimizations For You
-
-[Click here for more information](http://lwc-redux.com/why-use-lwc-redux)
-
-## Basic Tutorial
-
-To see how to use LWC Redux in practice, we’ll show a step-by-step example by creating a todo list app.
-
-[Click here for basic tutorial](http://lwc-redux.com/basic-tutorial)
-
-
-## Examples
-
-Go to Examples folder in the repository or [refer examples page](http://lwc-redux.com/examples)
+1. [Set up CumulusCI](https://cumulusci.readthedocs.io/en/latest/tutorial.html)
+2. Run `cci flow run dev_org --org dev` to deploy this project.
+3. Run `cci org browser dev` to open the org in your browser.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,38 @@
-# lwc-redux
+# Introducing Redux with Lightning web components(LWC)
 
-Add a brief description of this project here, in Markdown format.
-It will be shown on the main page of the project's GitHub repository.
+[LWC-redux](http://lwc-redux.com/) is a [LWC](https://developer.salesforce.com/blogs/2018/12/introducing-lightning-web-components.html) binding for [Redux](https://redux.js.org/introduction/getting-started#basic-example). It will allow your Lightning Web Components to read data from a Redux store, and dispatch actions to the store to update data.
 
-## Development
+LWC-redux helps you to write application that behaves consistently and provide state management to the application. It's also separate the JS business and design layers.
 
-To work on this project in a scratch org:
+## Installation
 
-1. [Set up CumulusCI](https://cumulusci.readthedocs.io/en/latest/tutorial.html)
-2. Run `cci flow run dev_org --org dev` to deploy this project.
-3. Run `cci org browser dev` to open the org in your browser.
+To install the LWC-redux, we only need to click on the below button. It will redirect you to another page where you can select production/sandbox org and proceed with 'Login to Salesforce' button.
+[Click here to install](http://lwc-redux.com/quick-start#installation)
+
+There are two types of developer processes or models supported in Salesforce Extensions for VS Code and Salesforce CLI. These models are explained below. Each model offers pros and cons and is fully supported.
+
+## Why Use LWC Redux?
+
+Redux itself is a standalone library that can be used with any UI layer or framework, including LWC, React, Angular, Vue, Ember, and vanilla JS. Although Redux and React are commonly used together, they are independent of each other.
+
+If you are using Redux with any kind of UI framework, you will normally use a "UI binding" library to tie Redux together with your UI framework, rather than directly interacting with the store from your UI code.
+
+LWC Redux is the Redux UI binding library for LWC. If you are using Redux and LWC together, you should also use LWC Redux to bind these two libraries.
+
+##### It is the Redux UI Bindings for LWC.
+
+##### It Encourages Good LWC Architecture.
+
+##### It Implements Performance Optimizations For You
+
+[Click here for more information](http://lwc-redux.com/why-use-lwc-redux)
+
+## Basic Tutorial
+
+To see how to use LWC Redux in practice, we’ll show a step-by-step example by creating a todo list app.
+
+[Click here for basic tutorial](http://lwc-redux.com/basic-tutorial)
+
+## Examples
+
+Go to Examples folder in the repository or [refer examples page](http://lwc-redux.com/examples)

--- a/cumulusci.yml
+++ b/cumulusci.yml
@@ -1,0 +1,24 @@
+minimum_cumulusci_version: '3.21.1'
+project:
+    name: lwc-redux
+    package:
+        name: lwc-redux
+        api_version: '49.0'
+    git:
+    source_format: sfdx
+
+tasks:
+    robot:
+        options:
+            suites: robot/lwc-redux/tests
+            options:
+                outputdir: robot/lwc-redux/results
+
+    robot_testdoc:
+        options:
+            path: robot/lwc-redux/tests
+            output: robot/lwc-redux/doc/lwc-redux_tests.html
+
+    run_tests:
+        options:
+            required_org_code_coverage_percent: 75

--- a/orgs/beta.json
+++ b/orgs/beta.json
@@ -1,0 +1,20 @@
+{
+  "orgName": "lwc-redux - Beta Test Org",
+  "edition": "Developer",
+  "settings": {
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    },
+    "chatterSettings": {
+      "enableChatter": true
+    },
+    "userManagementSettings": {
+      "enableNewProfileUI": true
+    },
+    "securitySettings": {
+      "enableAdminLoginAsAnyUser": true,
+      "sessionSettings": {
+        "forceRelogin": false
+      }
+    }  }
+}

--- a/orgs/dev.json
+++ b/orgs/dev.json
@@ -1,0 +1,24 @@
+{
+  "orgName": "lwc-redux - Dev Org",
+  "edition": "Developer",
+  "settings": {
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    },
+    "chatterSettings": {
+      "enableChatter": true
+    },
+    "userManagementSettings": {
+      "enableNewProfileUI": true
+    },
+    "securitySettings": {
+      "enableAdminLoginAsAnyUser": true,
+      "sessionSettings": {
+        "forceRelogin": false
+      }
+    },
+    "languageSettings": {
+      "enableTranslationWorkbench": true
+    }
+  }
+}

--- a/orgs/feature.json
+++ b/orgs/feature.json
@@ -1,0 +1,24 @@
+{
+  "orgName": "lwc-redux - Feature Test Org",
+  "edition": "Developer",
+  "settings": {
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    },
+    "chatterSettings": {
+      "enableChatter": true
+    },
+    "userManagementSettings": {
+      "enableNewProfileUI": true
+    },
+    "securitySettings": {
+      "enableAdminLoginAsAnyUser": true,
+      "sessionSettings": {
+        "forceRelogin": false
+      }
+    },
+    "languageSettings": {
+      "enableTranslationWorkbench": true
+    }
+  }
+}

--- a/orgs/release.json
+++ b/orgs/release.json
@@ -1,0 +1,20 @@
+{
+  "orgName": "lwc-redux - Release Test Org",
+  "edition": "Enterprise",
+  "settings": {
+    "lightningExperienceSettings": {
+      "enableS1DesktopEnabled": true
+    },
+    "chatterSettings": {
+      "enableChatter": true
+    },
+    "userManagementSettings": {
+      "enableNewProfileUI": true
+    },
+    "securitySettings": {
+      "enableAdminLoginAsAnyUser": true,
+      "sessionSettings": {
+        "forceRelogin": false
+      }
+    }  }
+}


### PR DESCRIPTION
This allows cumulusci projects to install this repo's metadata without having to install a package. The scratch org defs are from the cci project init, as are changes to the .gitignore.